### PR TITLE
Add get_option attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,3 +186,32 @@ impl Foo {
     }
 }
 ```
+
+Getters that return `&Option<T>` can lead to boilerplate code, as they require 
+the user to pollute code with `.as_ref()` everywhere. This can be changed by using 
+the `get_option` attribute on struct or field level. 
+Note the following syntaxes are supported for Options: 
+- Option
+- std::option::Option
+- ::std::option::Option
+- core::option::Option
+- ::core::option::Option
+
+However own type aliases like `type Bar<T> = Option<T>` are not supported.
+
+```rust
+use getset::{OptionGetters};
+
+#[derive(OptionGetters)]
+#[getset(get_option)]
+pub struct Foo {
+    field: Option<usize>,
+}
+
+impl Foo {
+    #[inline(always)]
+    fn field(&self) -> Option<&usize> {
+        self.field.as_ref()
+    }
+}
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,6 +223,23 @@ pub fn copy_getters(input: TokenStream) -> TokenStream {
     gen.into()
 }
 
+#[proc_macro_derive(OptionGetters, attributes(get_option, with_prefix, getset))]
+#[proc_macro_error]
+pub fn option_getters(input: TokenStream) -> TokenStream {
+    // Parse the string representation
+    let ast: DeriveInput = syn::parse(input).expect_or_abort("Couldn't parse for getters");
+    let params = GenParams {
+        mode: GenMode::GetOption,
+        global_attr: parse_global_attr(&ast.attrs, GenMode::GetOption),
+    };
+
+    // Build the impl
+    let gen = produce(&ast, &params);
+
+    // Return the generated impl
+    gen.into()
+}
+
 #[proc_macro_derive(MutGetters, attributes(get_mut, getset))]
 #[proc_macro_error]
 pub fn mut_getters(input: TokenStream) -> TokenStream {
@@ -274,6 +291,7 @@ fn parse_attr(attr: &syn::Attribute, mode: GenMode) -> Option<Meta> {
             .inspect(|meta| {
                 if !(meta.path().is_ident("get")
                     || meta.path().is_ident("get_copy")
+                    || meta.path().is_ident("get_option")
                     || meta.path().is_ident("get_mut")
                     || meta.path().is_ident("set")
                     || meta.path().is_ident("skip"))

--- a/tests/option_getters.rs
+++ b/tests/option_getters.rs
@@ -1,0 +1,211 @@
+#[macro_use]
+extern crate getset;
+
+use crate::submodule::other::{
+    Generic, OptionPath1, OptionPath2, OptionPath3, OptionPath4, Plain, Where,
+};
+
+// For testing `pub(super)`
+mod submodule {
+    // For testing `pub(super::other)`
+    pub mod other {
+
+        #[derive(OptionGetters)]
+        #[get_option]
+        pub struct Plain {
+            /// A doc comment.
+            /// Multiple lines, even.
+            private_accessible: Option<String>,
+
+            /// A doc comment.
+            #[get_option = "pub"]
+            public_accessible: Option<String>,
+
+            // Prefixed getter.
+            #[get_option = "with_prefix"]
+            private_prefixed: Option<String>,
+
+            // Prefixed getter.
+            #[get_option = "pub with_prefix"]
+            public_prefixed: Option<String>,
+        }
+
+        impl Default for Plain {
+            fn default() -> Plain {
+                Plain {
+                    private_accessible: Some("17".to_string()),
+                    public_accessible: Some("18".to_string()),
+                    private_prefixed: Some("19".to_string()),
+                    public_prefixed: Some("20".to_string()),
+                }
+            }
+        }
+
+        #[derive(OptionGetters, Default)]
+        #[get_option]
+        pub struct Generic<T: Copy + Clone + Default> {
+            /// A doc comment.
+            /// Multiple lines, even.
+            private_accessible: Option<T>,
+
+            /// A doc comment.
+            #[get_option = "pub"]
+            public_accessible: Option<T>,
+        }
+
+        #[derive(OptionGetters, Getters, Default)]
+        #[get_option]
+        pub struct Where<T>
+        where
+            T: Copy + Clone + Default,
+        {
+            /// A doc comment.
+            /// Multiple lines, even.
+            private_accessible: Option<T>,
+
+            /// A doc comment.
+            #[get_option = "pub"]
+            public_accessible: Option<T>,
+        }
+
+        #[derive(OptionGetters)]
+        #[get_option]
+        pub struct OptionPath1 {
+            /// A doc comment.
+            /// Multiple lines, even.
+            #[get_option = "pub"]
+            public_accessible: std::option::Option<usize>,
+        }
+
+        impl Default for OptionPath1 {
+            fn default() -> Self {
+                Self {
+                    public_accessible: Some(42),
+                }
+            }
+        }
+
+        #[derive(OptionGetters)]
+        #[get_option]
+        pub struct OptionPath2 {
+            /// A doc comment.
+            /// Multiple lines, even.
+            #[get_option = "pub"]
+            public_accessible: ::std::option::Option<usize>,
+        }
+
+        impl Default for OptionPath2 {
+            fn default() -> Self {
+                Self {
+                    public_accessible: Some(42),
+                }
+            }
+        }
+
+        #[derive(OptionGetters)]
+        #[get_option]
+        pub struct OptionPath3 {
+            /// A doc comment.
+            /// Multiple lines, even.
+            #[get_option = "pub"]
+            public_accessible: core::option::Option<usize>,
+        }
+
+        impl Default for OptionPath3 {
+            fn default() -> Self {
+                Self {
+                    public_accessible: Some(42),
+                }
+            }
+        }
+
+        #[derive(OptionGetters)]
+        #[get_option]
+        pub struct OptionPath4 {
+            /// A doc comment.
+            /// Multiple lines, even.
+            #[get_option = "pub"]
+            public_accessible: ::core::option::Option<usize>,
+        }
+
+        impl Default for OptionPath4 {
+            fn default() -> Self {
+                Self {
+                    public_accessible: Some(42),
+                }
+            }
+        }
+
+        #[test]
+        fn test_plain() {
+            let val = Plain::default();
+            val.private_accessible();
+        }
+
+        #[test]
+        fn test_generic() {
+            let val = Generic::<usize>::default();
+            val.private_accessible();
+        }
+
+        #[test]
+        fn test_where() {
+            let val = Where::<usize>::default();
+            val.private_accessible();
+        }
+
+        #[test]
+        fn test_prefixed_plain() {
+            let val = Plain::default();
+            assert_eq!(Some(&"19".to_string()), val.get_private_prefixed());
+        }
+    }
+}
+
+#[test]
+fn test_plain() {
+    let val = Plain::default();
+    assert_eq!(Some(&"18".to_string()), val.public_accessible());
+}
+
+#[test]
+fn test_generic() {
+    let val = Generic::<usize>::default();
+    assert_eq!(None, val.public_accessible());
+}
+
+#[test]
+fn test_where() {
+    let val = Where::<usize>::default();
+    assert_eq!(None, val.public_accessible());
+}
+
+#[test]
+fn test_prefixed_plain() {
+    let val = Plain::default();
+    assert_eq!(Some(&"20".to_string()), val.get_public_prefixed());
+}
+
+#[test]
+fn test_option_path1() {
+    let val = OptionPath1::default();
+    assert_eq!(Some(&42), val.public_accessible());
+}
+
+#[test]
+fn test_option_path2() {
+    let val = OptionPath2::default();
+    assert_eq!(Some(&42), val.public_accessible());
+}
+
+#[test]
+fn test_option_path3() {
+    let val = OptionPath3::default();
+    assert_eq!(Some(&42), val.public_accessible());
+}
+
+#[test]
+fn test_option_path4() {
+    let val = OptionPath4::default();
+    assert_eq!(Some(&42), val.public_accessible());
+}

--- a/tests/option_getters.rs
+++ b/tests/option_getters.rs
@@ -2,7 +2,7 @@
 extern crate getset;
 
 use crate::submodule::other::{
-    Generic, OptionPath1, OptionPath2, OptionPath3, OptionPath4, Plain, Where,
+    Generic, Mixed, OptionPath1, OptionPath2, OptionPath3, OptionPath4, Plain, Where,
 };
 
 // For testing `pub(super)`
@@ -66,6 +66,23 @@ mod submodule {
             /// A doc comment.
             #[get_option = "pub"]
             public_accessible: Option<T>,
+        }
+
+        #[derive(Getters, OptionGetters)]
+        pub struct Mixed {
+            #[getset(get = "pub")]
+            field: usize,
+            #[getset(get_option = "pub")]
+            optional_field: Option<usize>,
+        }
+
+        impl Default for Mixed {
+            fn default() -> Self {
+                Self {
+                    field: 101,
+                    optional_field: Some(22),
+                }
+            }
         }
 
         #[derive(OptionGetters)]
@@ -155,6 +172,13 @@ mod submodule {
         }
 
         #[test]
+        fn test_mixed() {
+            let val = Mixed::default();
+            val.field();
+            val.optional_field();
+        }
+
+        #[test]
         fn test_prefixed_plain() {
             let val = Plain::default();
             assert_eq!(Some(&"19".to_string()), val.get_private_prefixed());
@@ -178,6 +202,13 @@ fn test_generic() {
 fn test_where() {
     let val = Where::<usize>::default();
     assert_eq!(None, val.public_accessible());
+}
+
+#[test]
+fn test_mixed() {
+    let val = Mixed::default();
+    assert_eq!(101, *val.field());
+    assert_eq!(Some(&22), val.optional_field());
 }
 
 #[test]


### PR DESCRIPTION
Implements #78 

Hi @Hoverbear, first of all thanks for your work!
I stumbled across the same issue as mentioned in #78 and tried to implement the suggested solution. 
This PR adds a new attribute `get_option` to getset, so that the getter function returns `Option<&T>` instead of `&Option<T>`. 

Note the following syntaxes are supported (and tested) for Options: 
- Option
- std::option::Option
- ::std::option::Option
- core::option::Option
- ::core::option::Option

However own type aliases like `type Bar<T> = Option<T>` are not supported.


The following code:
```rust
use getset::{OptionGetters};
#[derive(OptionGetters)]
#[getset(get_option)]
pub struct Foo {
    field: Option<usize>,
}
```
derives 
```rust
impl Foo {
    #[inline(always)]
    fn field(&self) -> Option<&usize> {
        self.field.as_ref()
    }
}
```

Unfortunately, I have little experience with procedural macros so far and hope that I have implemented the suggestion in an acceptable way. 