### PR TITLE
Add 'WithSetters' proc_macro_derive, change version to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,11 @@ Getset, we're ready to go!
 
 A procedural macro for generating the most basic getters and setters on fields.
 """
-version = "0.1.3"
-authors = ["Ana Hobden <ana@hoverbear.org>", "John Baublitz <john.m.baublitz@gmail.com"]
+version = "0.2.0"
+authors = [
+    "Ana Hobden <ana@hoverbear.org>",
+    "John Baublitz <john.m.baublitz@gmail.com",
+]
 license = "MIT"
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -14,21 +14,21 @@ Getters are generated as `fn field(&self) -> &type`, while setters are generated
 These macros are not intended to be used on fields which require custom logic inside of their setters and getters. Just write your own in that case!
 
 ```rust
-use getset::{CopyGetters, Getters, MutGetters, Setters};
+use getset::{CopyGetters, Getters, MutGetters, Setters, WithSetters};
 
-#[derive(Getters, Setters, MutGetters, CopyGetters, Default)]
+#[derive(Getters, Setters, MutGetters, CopyGetters, WithSetters, Default)]
 pub struct Foo<T>
 where
     T: Copy + Clone + Default,
 {
     /// Doc comments are supported!
     /// Multiline, even.
-    #[getset(get, set, get_mut)]
+    #[getset(get, set, get_mut, set_with)]
     private: T,
 
     /// Doc comments are supported!
     /// Multiline, even.
-    #[getset(get_copy = "pub", set = "pub", get_mut = "pub")]
+    #[getset(get_copy = "pub", set = "pub", get_mut = "pub", set_with = "pub")]
     public: T,
 }
 
@@ -37,13 +37,15 @@ fn main() {
     foo.set_private(1);
     (*foo.private_mut()) += 1;
     assert_eq!(*foo.private(), 2);
+    foo = foo.with_private(3);
+    assert_eq!(*foo.private(), 3);
 }
 ```
 
 You can use `cargo-expand` to generate the output. Here are the functions that the above generates (Replicate with `cargo expand --example simple`):
 
 ```rust
-use getset::{Getters, MutGetters, CopyGetters, Setters};
+use getset::{CopyGetters, Getters, MutGetters, Setters, WithSetters};
 pub struct Foo<T>
 where
     T: Copy + Clone + Default,
@@ -54,7 +56,7 @@ where
     private: T,
     /// Doc comments are supported!
     /// Multiline, even.
-    #[getset(get_copy = "pub", set = "pub", get_mut = "pub")]
+    #[getset(get_copy = "pub", set = "pub", get_mut = "pub", set_with = "pub")]
     public: T,
 }
 impl<T> Foo<T>
@@ -106,6 +108,18 @@ where
     #[inline(always)]
     pub fn public(&self) -> T {
         self.public
+    }
+}
+impl<T> Foo<T>
+where
+    T: Copy + Clone + Default,
+{
+    /// Doc comments are supported!
+    /// Multiline, even.
+    #[inline(always)]
+    pub fn with_public(mut self, val: T) -> Self {
+        self.public = val;
+        self
     }
 }
 ```
@@ -162,7 +176,7 @@ is possible with `#[getset(skip)]`.
 use getset::{CopyGetters, Setters};
 
 #[derive(CopyGetters, Setters)]
-#[getset(get_copy, set)]
+#[getset(get_copy, set, set_with)]
 pub struct Foo {
     // If the field was not skipped, the compiler would complain about moving
     // a non-copyable type in copy getter.
@@ -181,6 +195,11 @@ impl Foo {
     }
 
     fn set_skipped(&mut self, val: &str) -> &mut Self {
+        self.skipped = val.to_string();
+        self
+    }
+
+    fn with_skipped(mut self, val: &str) -> Self {
         self.skipped = val.to_string();
         self
     }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,18 +1,18 @@
-use getset::{CopyGetters, Getters, MutGetters, Setters};
+use getset::{CopyGetters, Getters, MutGetters, Setters, WithSetters};
 
-#[derive(Getters, Setters, MutGetters, CopyGetters, Default)]
+#[derive(Getters, Setters, WithSetters, MutGetters, CopyGetters, Default)]
 pub struct Foo<T>
 where
     T: Copy + Clone + Default,
 {
     /// Doc comments are supported!
     /// Multiline, even.
-    #[getset(get, set, get_mut)]
+    #[getset(get, set, get_mut, set_with)]
     private: T,
 
     /// Doc comments are supported!
     /// Multiline, even.
-    #[getset(get_copy = "pub", set = "pub", get_mut = "pub")]
+    #[getset(get_copy = "pub", set = "pub", get_mut = "pub", set_with = "pub")]
     public: T,
 }
 
@@ -21,4 +21,6 @@ fn main() {
     foo.set_private(1);
     (*foo.private_mut()) += 1;
     assert_eq!(*foo.private(), 2);
+    foo = foo.with_private(3);
+    assert_eq!(*foo.private(), 3);
 }

--- a/tests/skip.rs
+++ b/tests/skip.rs
@@ -1,8 +1,8 @@
 #[macro_use]
 extern crate getset;
 
-#[derive(CopyGetters, Setters)]
-#[getset(get_copy, set)]
+#[derive(CopyGetters, Setters, WithSetters)]
+#[getset(get_copy, set, set_with)]
 pub struct Plain {
     // If the field was not skipped, the compiler would complain about moving a
     // non-copyable type.
@@ -30,6 +30,13 @@ impl Plain {
         self.non_copyable = val;
         self
     }
+
+    // If the field was not skipped, the compiler would complain about duplicate
+    // definitions of `with_non_copyable`.
+    fn with_non_copyable(mut self, val: String) -> Self {
+        self.non_copyable = val;
+        self
+    }
 }
 
 impl Default for Plain {
@@ -47,4 +54,6 @@ fn test_plain() {
     val.copyable();
     val.custom_non_copyable();
     val.set_non_copyable("bar".to_string());
+    val = val.with_non_copyable("foo".to_string());
+    let _ = val;
 }

--- a/tests/with_setters.rs
+++ b/tests/with_setters.rs
@@ -1,0 +1,130 @@
+#[macro_use]
+extern crate getset;
+
+use crate::submodule::other::{Generic, Plain, Where};
+
+// For testing `pub(super)`
+mod submodule {
+    // For testing `pub(in super::other)`
+    pub mod other {
+        #[derive(WithSetters, Default)]
+        #[set_with]
+        pub struct Plain {
+            /// A doc comment.
+            /// Multiple lines, even.
+            private_accessible: usize,
+
+            /// A doc comment.
+            #[set_with = "pub"]
+            public_accessible: usize,
+
+            /// This field is used for testing chaining.
+            #[set_with = "pub"]
+            second_public_accessible: bool,
+            // /// A doc comment.
+            // #[set_with = "pub(crate)"]
+            // crate_accessible: usize,
+
+            // /// A doc comment.
+            // #[set_with = "pub(super)"]
+            // super_accessible: usize,
+
+            // /// A doc comment.
+            // #[set_with = "pub(in super::other)"]
+            // scope_accessible: usize,
+        }
+
+        #[derive(WithSetters, Default)]
+        #[set_with]
+        pub struct Generic<T: Copy + Clone + Default> {
+            /// A doc comment.
+            /// Multiple lines, even.
+            private_accessible: T,
+
+            /// A doc comment.
+            #[set_with = "pub"]
+            public_accessible: T,
+            // /// A doc comment.
+            // #[set_with = "pub(crate)"]
+            // crate_accessible: usize,
+
+            // /// A doc comment.
+            // #[set_with = "pub(super)"]
+            // super_accessible: usize,
+
+            // /// A doc comment.
+            // #[set_with = "pub(in super::other)"]
+            // scope_accessible: usize,
+        }
+
+        #[derive(WithSetters, Default)]
+        #[set_with]
+        pub struct Where<T>
+        where
+            T: Copy + Clone + Default,
+        {
+            /// A doc comment.
+            /// Multiple lines, even.
+            private_accessible: T,
+
+            /// A doc comment.
+            #[set_with = "pub"]
+            public_accessible: T,
+            // /// A doc comment.
+            // #[set_with = "pub(crate)"]
+            // crate_accessible: usize,
+
+            // /// A doc comment.
+            // #[set_with = "pub(super)"]
+            // super_accessible: usize,
+
+            // /// A doc comment.
+            // #[set_with = "pub(in super::other)"]
+            // scope_accessible: usize,
+        }
+
+        #[test]
+        fn test_plain() {
+            let val: Plain = Plain::default();
+            let _: Plain = val.with_private_accessible(1);
+        }
+
+        #[test]
+        fn test_generic() {
+            let val: Generic<i32> = Generic::default();
+            let _: Generic<i32> = val.with_private_accessible(1);
+        }
+
+        #[test]
+        fn test_where() {
+            let val: Where<i32> = Where::default();
+            let _: Where<i32> = val.with_private_accessible(1);
+        }
+    }
+}
+
+#[test]
+fn test_plain() {
+    let val: Plain = Plain::default();
+    let _: Plain = val.with_public_accessible(1);
+}
+
+#[test]
+fn test_generic() {
+    let val: Generic<i32> = Generic::default();
+    let _: Generic<i32> = val.with_public_accessible(1);
+}
+
+#[test]
+fn test_where() {
+    let val: Where<i32> = Where::default();
+    let _: Where<i32> = val.with_public_accessible(1);
+}
+
+#[test]
+fn test_chaining() {
+    let val: Plain = Plain::default();
+    let _: Plain = val
+        .with_public_accessible(1)
+        .with_second_public_accessible(true);
+}


### PR DESCRIPTION
```rust
GenMode::SetWith => {
    quote! {
        #(#doc)*
        #[inline(always)]
        #visibility fn #fn_name(mut self, val: #ty) -> Self {
            self.#field_name = val;
            self
        }
    }
}
```

`fn_name` is `with_{field_name}`

Demonstration of usage scenarios:

```rust
#[derive(Debug, getset::WithSetters)]
#[set_with]
struct Config {
    timeout: u32,
    retries: u8,
    address: String,
}

impl Config {
    pub fn new() -> Self {
        Config { timeout: 30, retries: 3, address: "127.0.0.1".to_string() }
    }
}

// Generate by getset::WithSetters:
impl Config {
    pub fn with_timeout(mut self, timeout: u32) -> Self {
        self.timeout = timeout;
        self
    }
    
    pub fn with_retries(mut self, retries: u8) -> Self {
        self.retries = retries;
        self
    }
    
    pub fn with_address(mut self, address: String) -> Self {
        self.address = address;
        self
    }
}

fn main() {
    let config = Config::new()
        .with_timeout(60)
        .with_retries(5)
        .with_address("192.168.1.1".to_string());

    println!("{:?}", config);  // Outupt: Config { timeout: 60, retries: 5, address: "192.168.1.1" }
}
```