### PR TITLE
Unary tuple struct getter/setter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,6 +179,8 @@ the macro generates the `get`, `get_mut`, and `set` functions to
 provide a getter, a mutable getter, and a setter, respectively.
 
 ```rust
+use getset::{Getters, MutGetters, CopyGetters, Setters};
+
 #[derive(Setters, Getters, MutGetters)]
 struct UnaryTuple(#[getset(set, get, get_mut)] i32);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,6 +173,26 @@ impl Foo {
     }
 }
 ```
+
+For a unary struct (a tuple struct with a single field),
+the macro generates the `get`, `get_mut`, and `set` functions to
+provide a getter, a mutable getter, and a setter, respectively.
+
+```rust
+#[derive(Setters, Getters, MutGetters)]
+struct UnaryTuple(#[getset(set, get, get_mut)] i32);
+
+let mut tup = UnaryTuple(42);
+assert_eq!(tup.get(), &42);
+assert_eq!(tup.get_mut(), &mut 42);
+tup.set(43);
+assert_eq!(tup.get(), &43);
+
+#[derive(CopyGetters)]
+struct CopyUnaryTuple(#[getset(get_copy)] i32);
+
+let tup = CopyUnaryTuple(42);
+```
 */
 
 #[macro_use]

--- a/tests/unary_tuple.rs
+++ b/tests/unary_tuple.rs
@@ -17,3 +17,23 @@ fn test_unary_tuple() {
     let tup = CopyUnaryTuple(42);
     assert_eq!(tup.get(), 42);
 }
+
+#[test]
+fn test_unary_tuple_with_attrs() {
+    #[derive(Setters, Getters, MutGetters)]
+    #[getset(set, get, get_mut)]
+    struct UnaryTuple(i32);
+
+    let mut tup = UnaryTuple(42);
+    assert_eq!(tup.get(), &42);
+    assert_eq!(tup.get_mut(), &mut 42);
+    tup.set(43);
+    assert_eq!(tup.get(), &43);
+
+    #[derive(CopyGetters)]
+    #[getset(get_copy)]
+    struct CopyUnaryTuple(i32);
+
+    let tup = CopyUnaryTuple(42);
+    assert_eq!(tup.get(), 42);
+}

--- a/tests/unary_tuple.rs
+++ b/tests/unary_tuple.rs
@@ -1,0 +1,19 @@
+use getset::{CopyGetters, Getters, MutGetters, Setters};
+
+#[test]
+fn test_unary_tuple() {
+    #[derive(Setters, Getters, MutGetters)]
+    struct UnaryTuple(#[getset(set, get, get_mut)] i32);
+
+    let mut tup = UnaryTuple(42);
+    assert_eq!(tup.get(), &42);
+    assert_eq!(tup.get_mut(), &mut 42);
+    tup.set(43);
+    assert_eq!(tup.get(), &43);
+
+    #[derive(CopyGetters)]
+    struct CopyUnaryTuple(#[getset(get_copy)] i32);
+
+    let tup = CopyUnaryTuple(42);
+    assert_eq!(tup.get(), 42);
+}


### PR DESCRIPTION
An implementation for #90 feature.
```rust
#[derive(Setters, Getters, MutGetters)]
struct UnaryTuple(#[getset(set, get, get_mut)] i32);

let mut tup = UnaryTuple(42);
assert_eq!(tup.get(), &42);
assert_eq!(tup.get_mut(), &mut 42);
tup.set(43);
assert_eq!(tup.get(), &43);

#[derive(CopyGetters)]
struct CopyUnaryTuple(#[getset(get_copy)] i32);

let tup = CopyUnaryTuple(42);
```