### PR TITLE
Add `impl_attrs` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,6 @@ quote = "1"
 syn = "2"
 proc-macro2 = { version = "1", default-features = false }
 proc-macro-error2 = "2"
+
+[dev-dependencies]
+fixture = { path = "tests/fixture" }

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -71,7 +71,7 @@ fn expr_to_string(expr: &Expr) -> Option<String> {
 }
 
 // Helper function to parse visibility
-fn parse_vis_str(s: &str, span: proc_macro2::Span) -> Visibility {
+fn parse_vis_str(s: &str, span: Span) -> Visibility {
     match syn::parse_str(s) {
         Ok(vis) => vis,
         Err(e) => abort!(span, "Invalid visibility found: {}", e),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,6 +226,18 @@ pub fn getters(input: TokenStream) -> TokenStream {
     produce(&ast, &params).into()
 }
 
+#[proc_macro_derive(CloneGetters, attributes(get_clone, with_prefix, getset))]
+#[proc_macro_error]
+pub fn clone_getters(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    let params = GenParams {
+        mode: GenMode::GetClone,
+        global_attr: parse_global_attr(&ast.attrs, GenMode::GetClone),
+    };
+
+    produce(&ast, &params).into()
+}
+
 #[proc_macro_derive(CopyGetters, attributes(get_copy, with_prefix, getset))]
 #[proc_macro_error]
 pub fn copy_getters(input: TokenStream) -> TokenStream {
@@ -292,6 +304,7 @@ fn parse_attr(attr: &syn::Attribute, mode: GenMode) -> Option<syn::Meta> {
             .into_iter()
             .inspect(|meta| {
                 if !(meta.path().is_ident("get")
+                    || meta.path().is_ident("get_clone")
                     || meta.path().is_ident("get_copy")
                     || meta.path().is_ident("get_mut")
                     || meta.path().is_ident("set")

--- a/tests/clone_getters.rs
+++ b/tests/clone_getters.rs
@@ -51,7 +51,7 @@ mod submodule {
 
         #[derive(CloneGetters, Default)]
         #[get_clone]
-        pub struct Generic<T:  Clone + Default> {
+        pub struct Generic<T: Clone + Default> {
             /// A doc comment.
             /// Multiple lines, even.
             private_accessible: T,

--- a/tests/clone_getters.rs
+++ b/tests/clone_getters.rs
@@ -1,0 +1,149 @@
+#[macro_use]
+extern crate getset;
+
+use crate::submodule::other::{Generic, Plain, Where};
+
+// For testing `pub(super)`
+mod submodule {
+    // For testing `pub(super::other)`
+    pub mod other {
+        #[derive(CloneGetters)]
+        #[get_clone]
+        pub struct Plain {
+            /// A doc comment.
+            /// Multiple lines, even.
+            private_accessible: Box<usize>,
+
+            /// A doc comment.
+            #[get_clone = "pub"]
+            public_accessible: Box<usize>,
+            // /// A doc comment.
+            // #[get_clone = "pub(crate)"]
+            // crate_accessible: Box<usize>,
+
+            // /// A doc comment.
+            // #[get_clone = "pub(super)"]
+            // super_accessible: Box<usize>,
+
+            // /// A doc comment.
+            // #[get_clone = "pub(super::other)"]
+            // scope_accessible: Box<usize>,
+
+            // Prefixed getter.
+            #[get_clone = "with_prefix"]
+            private_prefixed: Box<usize>,
+
+            // Prefixed getter.
+            #[get_clone = "pub with_prefix"]
+            public_prefixed: Box<usize>,
+        }
+
+        impl Default for Plain {
+            fn default() -> Plain {
+                Plain {
+                    private_accessible: Box::new(17),
+                    public_accessible: Box::new(18),
+                    private_prefixed: Box::new(19),
+                    public_prefixed: Box::new(20),
+                }
+            }
+        }
+
+        #[derive(CloneGetters, Default)]
+        #[get_clone]
+        pub struct Generic<T:  Clone + Default> {
+            /// A doc comment.
+            /// Multiple lines, even.
+            private_accessible: T,
+
+            /// A doc comment.
+            #[get_clone = "pub"]
+            public_accessible: T,
+            // /// A doc comment.
+            // #[get_clone = "pub(crate)"]
+            // crate_accessible: T,
+
+            // /// A doc comment.
+            // #[get_clone = "pub(super)"]
+            // super_accessible: T,
+
+            // /// A doc comment.
+            // #[get_clone = "pub(super::other)"]
+            // scope_accessible: T,
+        }
+
+        #[derive(CloneGetters, Getters, Default)]
+        #[get_clone]
+        pub struct Where<T>
+        where
+            T: Clone + Default,
+        {
+            /// A doc comment.
+            /// Multiple lines, even.
+            private_accessible: T,
+
+            /// A doc comment.
+            #[get_clone = "pub"]
+            public_accessible: T,
+            // /// A doc comment.
+            // #[get_clone = "pub(crate)"]
+            // crate_accessible: T,
+
+            // /// A doc comment.
+            // #[get_clone = "pub(super)"]
+            // super_accessible: T,
+
+            // /// A doc comment.
+            // #[get_clone = "pub(super::other)"]
+            // scope_accessible: T,
+        }
+
+        #[test]
+        fn test_plain() {
+            let val = Plain::default();
+            val.private_accessible();
+        }
+
+        #[test]
+        fn test_generic() {
+            let val = Generic::<Box<usize>>::default();
+            val.private_accessible();
+        }
+
+        #[test]
+        fn test_where() {
+            let val = Where::<Box<usize>>::default();
+            val.private_accessible();
+        }
+
+        #[test]
+        fn test_prefixed_plain() {
+            let val = Plain::default();
+            assert_eq!(19, *val.get_private_prefixed());
+        }
+    }
+}
+
+#[test]
+fn test_plain() {
+    let val = Plain::default();
+    assert_eq!(18, *val.public_accessible());
+}
+
+#[test]
+fn test_generic() {
+    let val = Generic::<Box<usize>>::default();
+    assert_eq!(Box::default(), val.public_accessible());
+}
+
+#[test]
+fn test_where() {
+    let val = Where::<Box<usize>>::default();
+    assert_eq!(Box::default(), val.public_accessible());
+}
+
+#[test]
+fn test_prefixed_plain() {
+    let val = Plain::default();
+    assert_eq!(20, *val.get_public_prefixed());
+}

--- a/tests/fixture/Cargo.toml
+++ b/tests/fixture/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "fixture"
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro-error2 = "2.0.1"
+quote = "1.0.40"
+syn = { version = "2.0.100", features = ["full"] }

--- a/tests/fixture/src/lib.rs
+++ b/tests/fixture/src/lib.rs
@@ -1,0 +1,39 @@
+use proc_macro::TokenStream;
+use proc_macro_error2::{abort, proc_macro_error};
+use quote::quote;
+use syn::{parse_macro_input, spanned::Spanned as _, ImplItem, ItemImpl};
+
+#[proc_macro_attribute]
+#[proc_macro_error]
+pub fn add_1_to_implementation(_attr: TokenStream, item_impl: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(item_impl as ItemImpl);
+    let attrs = &input.attrs;
+    let name = &input.self_ty;
+    let (generics, ty_generics, where_clause) = &input.generics.split_for_impl();
+    let statements = &input
+        .items
+        .iter()
+        .map(|item| match item {
+            ImplItem::Fn(function) => {
+                let func_attrs = &function.attrs;
+                let sig = &function.sig;
+                let body = &function.block.stmts[0];
+                quote! {
+                    #(#func_attrs)*
+                    #sig {
+                        #body + 1
+                    }
+                }
+            }
+            _ => abort!(item.span(), "Expected a method."),
+        })
+        .collect::<Vec<_>>();
+
+    quote! {
+        #(#attrs)*
+        impl #generics #name #ty_generics #where_clause {
+            #(#statements)*
+        }
+    }
+    .into()
+}

--- a/tests/impl_attrs.rs
+++ b/tests/impl_attrs.rs
@@ -1,3 +1,4 @@
+use fixture::add_1_to_implementation;
 use getset::{CloneGetters, CopyGetters};
 
 #[derive(CopyGetters, CloneGetters)]

--- a/tests/impl_attrs.rs
+++ b/tests/impl_attrs.rs
@@ -1,0 +1,46 @@
+use getset::{CloneGetters, CopyGetters};
+
+#[derive(CopyGetters, CloneGetters)]
+#[getset(
+    get_clone = "with_prefix",
+    get_copy,
+    impl_attrs = r#"
+        #[add_1_to_implementation]
+        #[cfg(target_os = "linux")]
+        #[add_1_to_implementation]
+        #[allow(unused)]
+        #[add_1_to_implementation]
+    "#
+)]
+struct Wardrobe {
+    shirts: u8,
+    pants: u8,
+}
+
+#[test]
+fn basic() {
+    let wardrobe = Wardrobe {
+        shirts: 2,
+        pants: 1,
+    };
+    assert_eq!(
+        wardrobe.shirts(),
+        5,
+        "Function attribute not applied correctly."
+    );
+    assert_eq!(
+        wardrobe.pants(),
+        4,
+        "Function attribute not applied correctly."
+    );
+    assert_eq!(
+        wardrobe.get_shirts(),
+        5,
+        "Function attribute not applied correctly."
+    );
+    assert_eq!(
+        wardrobe.get_pants(),
+        4,
+        "Function attribute not applied correctly."
+    );
+}


### PR DESCRIPTION
Fix #113
Depends on #112

Seeing the proposed solution in #112 inspired me to contribute to the fun in this project since it was so close to what was actually needed for our open-source project. Therefore, this is my take on a solution to #113. I've based this feature on #112 but here's a cleaner [diff](https://github.com/SLUCHABLUB/getset/compare/6b495203f02505cbc8878b8713e8e79f90340184...guzman-raphael:getset:impl_attrs) that you can use to follow the logic; specifically I've tried to pay extra attention to each commit to make it easier to review.

Do let me know if I've done something horribly wrong since I'm just getting started with developing procedural macros. All feedback is welcome and thanks again for the awesome lib! :rocket: 
